### PR TITLE
Sum gasUsed, not gas limit

### DIFF
--- a/components/Emissions.tsx
+++ b/components/Emissions.tsx
@@ -107,5 +107,5 @@ function consumedGas(res: Transaction[]) {
 }
 
 function gasSum(acc: number, cur: Transaction) {
-  return acc + Number(cur.gas);
+  return acc + Number(cur.gasUsed);
 }


### PR DESCRIPTION
Etherscan's `gas` is the transaction's gas limit, not the actual gas used. For that, you need to refer to `gasUsed`